### PR TITLE
Forward association

### DIFF
--- a/__tests__/fixtures/queries/baseFilterTest.graphql
+++ b/__tests__/fixtures/queries/baseFilterTest.graphql
@@ -3,7 +3,7 @@ query text {
     ...nodes
   }
   backwardFilterOnPolymorphic: allParents(filter:{
-    taggsAsTaggable:{
+    taggable:{
       some:{
         id:{equalTo:1}
       }
@@ -24,7 +24,7 @@ query text {
     }
   }
   backwardUniqueOnPolymorphic: allForwards(filter:{
-    uniqueTaggAsTaggable:{
+    uniqueTaggable:{
       content:{equalTo:"unique tagged on forward2"}
     }
   }){

--- a/__tests__/fixtures/queries/baseFilterTest.graphql
+++ b/__tests__/fixtures/queries/baseFilterTest.graphql
@@ -3,7 +3,7 @@ query text {
     ...nodes
   }
   backwardFilterOnPolymorphic: allParents(filter:{
-    taggs:{
+    taggsAsTaggable:{
       some:{
         id:{equalTo:1}
       }
@@ -24,7 +24,7 @@ query text {
     }
   }
   backwardUniqueOnPolymorphic: allForwards(filter:{
-    uniqueTagg:{
+    uniqueTaggAsTaggable:{
       content:{equalTo:"unique tagged on forward2"}
     }
   }){

--- a/__tests__/integration/queries.test.ts
+++ b/__tests__/integration/queries.test.ts
@@ -47,8 +47,8 @@ beforeAll(() => {
       }),
     ]);
 
-    debug(printSchema(normal));
-    // printSchema(normal);
+    // debug(printSchema(normal));
+    printSchema(normal);
     return {
       normal,
     };
@@ -65,8 +65,10 @@ beforeAll(() => {
     // Get a new Postgres client instance.
     return await withPgClient(async pgClient => {
       // Add data to the client instance we are using.
+      console.log('adding data');
 
       await pgClient.query(await kitchenSinkData());
+      console.log('done adding data');
       // Run all of our queries in parallel.
       return await Promise.all(
         queryFileNames.map(async fileName => {

--- a/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
@@ -2280,7 +2280,7 @@ type Query implements Node {
     nodeId: ID!
   ): UniqueTagg
   uniqueTaggById(id: Int!): UniqueTagg
-  uniqueTaggByTaggableIdAndTaggableType(taggableId: Int!, taggableType: String!): UniqueTagg
+  uniqueTaggByUniqueTaggableIdAndUniqueTaggableType(uniqueTaggableId: Int!, uniqueTaggableType: String!): UniqueTagg
 }
 
 type RangeArrayType implements Node {
@@ -2662,8 +2662,8 @@ type UniqueTagg implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   \\"\\"\\"
   nodeId: ID!
-  taggableId: Int!
-  taggableType: String!
+  uniqueTaggableId: Int!
+  uniqueTaggableType: String!
 }
 
 \\"\\"\\"A connection to a list of \`UniqueTagg\` values.\\"\\"\\"
@@ -2701,10 +2701,10 @@ enum UniqueTaggsOrderBy {
   NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
-  TAGGABLE_ID_ASC
-  TAGGABLE_ID_DESC
-  TAGGABLE_TYPE_ASC
-  TAGGABLE_TYPE_DESC
+  UNIQUE_TAGGABLE_ID_ASC
+  UNIQUE_TAGGABLE_ID_DESC
+  UNIQUE_TAGGABLE_TYPE_ASC
+  UNIQUE_TAGGABLE_TYPE_DESC
 }
 
 \\"\\"\\"

--- a/__tests__/p-data.sql
+++ b/__tests__/p-data.sql
@@ -6,7 +6,7 @@ insert into p.taggs(id,taggable_id,taggable_type,content) values
 (1,1,'Parent','tagged on parent1'),
 (2,2,'Parent','tagged on parent2');
 
-insert into p.unique_taggs(id,taggable_id,taggable_type,content) values 
+insert into p.unique_taggs(id,unique_taggable_id,unique_taggable_type,content) values 
 (1,1,'Parent','unique tagged on parent1'),
 (2,2,'Forward','unique tagged on forward2');
 

--- a/__tests__/p-data.sql
+++ b/__tests__/p-data.sql
@@ -1,140 +1,108 @@
-insert into p.parent
-  (id, name)
-values
+insert into p.parent(id, name) values
   (1, 'parent1'),
   (2, 'parent2');
 
-insert into p.taggs
-  (id,taggable_id,taggable_type,content)
-values
-  (1, 1, 'Parent', 'tagged on parent1'),
-  (2, 2, 'Parent', 'tagged on parent2');
+insert into p.taggs(id,taggable_id,taggable_type,content) values 
+(1,1,'Parent','tagged on parent1'),
+(2,2,'Parent','tagged on parent2');
 
-insert into p.unique_taggs
-  (id,unique_taggable_id,unique_taggable_type,content)
-values
-  (1, 1, 'Parent', 'unique tagged on parent1'),
-  (2, 2, 'Forward', 'unique tagged on forward2');
+insert into p.unique_taggs(id,taggable_id,taggable_type,content) values 
+(1,1,'Parent','unique tagged on parent1'),
+(2,2,'Forward','unique tagged on forward2');
 
-insert into p.forward
-  (id, name)
-values
+insert into p.forward(id, name) values
   (1, 'forward1'),
   (2, 'forward2'),
   (3, 'forward3'),
   (4, 'forward4');
 
-insert into p.forward_compound
-  (forward_compound_1, forward_compound_2, name)
-values
+insert into p.forward_compound(forward_compound_1, forward_compound_2, name) values
   (1, 1, 'forwardCompound11'),
   (1, 2, 'forwardCompound12'),
   (2, 1, 'forwardCompound21'),
   (2, 2, 'forwardCompound22');
 
 insert into p.filterable
-  (id, "bit4", "bool", "bpchar4", "bytea", "char4", "cidr", "citext", "date", "float4", "float8", "hstore", "inet", "int2", "int4", "int8", "interval", "json", "jsonb", "macaddr", "money", "name", "numeric", "text", "time", "timestamp", "timestamptz", "timetz", "uuid", "varbit", "varchar", "xml", "parent_id", "forward_id", "forward_compound_1", "forward_compound_2", "backward_compound_1", "backward_compound_2")
-values
-  (1, B'0001', false, 'TEST', '\x01', 'TEST', null, 'TEST', '1999-01-01', 0.1, 0.1, 'key1=>1', '192.168.1/24', 1, 1, 1, 'P0Y0M1DT0H0M0S', null, '{"key1":1}', null, 0.1, 'TEST', 0.1, 'TEST', '00:01:00', '1999-01-01 00:00', '1999-01-01 00:00', '00:01:00', '00000000-0000-0000-0000-000000000001', B
-'0001',  'TEST',    null,  1,           1,            1,                    1,                    1,                     1),
-(2,  B'0010', true,   'Test',    '\x02',  'Test',  null,   'Test',   '1999-02-01', 0.2,      0.2,      'key2=>2', '192.168.1.2',  2,      2,      2,      'P0Y0M2DT0H0M0S', null,   '{"key2":2}', null,      0.2,     'Test', 0.2,       'Test', '00:02:00', '1999-02-01 00:00', '1999-02-01 00:00', '00:02:00', '00000000-0000-0000-0000-000000000002', B'0010',  'Test',    null,  1,           2,            1,                    2,                    1,                     2),
-(3,  B'0011', false,  'tEST',    '\x03',  'tEST',  null,   'tEST',   '1999-03-01', 0.3,      0.3,      'key3=>3', '192.168.1.3',  3,      3,      3,      'P0Y0M3DT0H0M0S', null,   '{"key3":3}', null,      0.3,     'tEST', 0.3,       'tEST', '00:03:00', '1999-03-01 00:00', '1999-03-01 00:00', '00:03:00', '00000000-0000-0000-0000-000000000003', B'0011',  'tEST',    null,  2,           3,            2,                    1,                    2,                     1),
-(4,  B'0100', false,  'test',    '\x04',  'test',  null,   'test',   '1999-04-01', 0.4,      0.4,      'key4=>4', '192.168.1.4',  4,      4,      4,      'P0Y0M4DT0H0M0S', null,   '{"key4":4}', null,      0.4,     'test', 0.4,       'test', '00:04:00', '1999-04-01 00:00', '1999-04-01 00:00', '00:04:00', '00000000-0000-0000-0000-000000000004', B'0100',  'test',    null,  2,           4,            2,                    2,                    2,                     2),
-(5,  null,    null,   null,      null,    null,    null,   null,     null,         null,     null,     null,      null,           null,   null,   null,   null,             null,   null,         null,      null,    null,   null,      null,   null,       null,               null,               null,       null,                                   null,     null,      null,  null,        null,         null,                 null,                 null,                  null);
+  (id, "bit4",  "bool", "bpchar4", "bytea", "char4", "cidr", "citext", "date",       "float4", "float8", "hstore",  "inet",         "int2", "int4", "int8", "interval",       "json", "jsonb",      "macaddr", "money", "name", "numeric", "text", "time",     "timestamp",        "timestamptz",      "timetz",   "uuid",                                 "varbit", "varchar", "xml", "parent_id", "forward_id", "forward_compound_1", "forward_compound_2", "backward_compound_1", "backward_compound_2") values
+  (1,  B'0001', false,  'TEST',    '\x01',  'TEST',  null,   'TEST',   '1999-01-01', 0.1,      0.1,      'key1=>1', '192.168.1/24', 1,      1,      1,      'P0Y0M1DT0H0M0S', null,   '{"key1":1}', null,      0.1,     'TEST', 0.1,       'TEST', '00:01:00', '1999-01-01 00:00', '1999-01-01 00:00', '00:01:00', '00000000-0000-0000-0000-000000000001', B'0001',  'TEST',    null,  1,           1,            1,                    1,                    1,                     1),
+  (2,  B'0010', true,   'Test',    '\x02',  'Test',  null,   'Test',   '1999-02-01', 0.2,      0.2,      'key2=>2', '192.168.1.2',  2,      2,      2,      'P0Y0M2DT0H0M0S', null,   '{"key2":2}', null,      0.2,     'Test', 0.2,       'Test', '00:02:00', '1999-02-01 00:00', '1999-02-01 00:00', '00:02:00', '00000000-0000-0000-0000-000000000002', B'0010',  'Test',    null,  1,           2,            1,                    2,                    1,                     2),
+  (3,  B'0011', false,  'tEST',    '\x03',  'tEST',  null,   'tEST',   '1999-03-01', 0.3,      0.3,      'key3=>3', '192.168.1.3',  3,      3,      3,      'P0Y0M3DT0H0M0S', null,   '{"key3":3}', null,      0.3,     'tEST', 0.3,       'tEST', '00:03:00', '1999-03-01 00:00', '1999-03-01 00:00', '00:03:00', '00000000-0000-0000-0000-000000000003', B'0011',  'tEST',    null,  2,           3,            2,                    1,                    2,                     1),
+  (4,  B'0100', false,  'test',    '\x04',  'test',  null,   'test',   '1999-04-01', 0.4,      0.4,      'key4=>4', '192.168.1.4',  4,      4,      4,      'P0Y0M4DT0H0M0S', null,   '{"key4":4}', null,      0.4,     'test', 0.4,       'test', '00:04:00', '1999-04-01 00:00', '1999-04-01 00:00', '00:04:00', '00000000-0000-0000-0000-000000000004', B'0100',  'test',    null,  2,           4,            2,                    2,                    2,                     2),
+  (5,  null,    null,   null,      null,    null,    null,   null,     null,         null,     null,     null,      null,           null,   null,   null,   null,             null,   null,         null,      null,    null,   null,      null,   null,       null,               null,               null,       null,                                   null,     null,      null,  null,        null,         null,                 null,                 null,                  null);
 
 insert into p.array_types
-  (id, "bit4_array", "bool_array", "bpchar4_array", "char4_array", "citext_array", "date_array", "float4_array", "float8_array", "hstore_array", "inet_array", "int2_array", "int4_array", "int8_array", "jsonb_array", "money_array", "numeric_array", "text_array", "time_array", "timestamp_array", "timestamptz_array", "timetz_array", "uuid_array", "varbit_array", "varchar_array")
-values
-  (1, '{0001,0010}', '{false,true}', '{TEST,Test}', '{TEST,Test}', '{TEST,Test}', '{1999-01-01,1999-02-01}', '{0.1,0.2}', '{0.1,0.2}', '{key1=>1,key2=>2}', '{192.168.1/24,192.168.1.2}', '{1,2}', '{1,2}', '{1,2}', '{"{\"key1\": 1}","{\"key2\": 2}"}', '{0.1,0.2}', '{0.1,0.2}', '{TEST,Test}', '{00:01:00,00:02:00}', '{1999-01-01 00:00,1999-02-01 00:00}', '{1999-01-01 00:00,1999-02-01 00:00}', '{00:01:00,00:02:00}', '{00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000002}', '{0001,0010}', '{TEST,Test}'),
-  (2, '{0010,0011}', '{true,false}', '{Test,tEST}', '{Test,tEST}', '{Test,tEST}', '{1999-02-01,1999-03-01}', '{0.2,0.3}', '{0.2,0.3}', '{key2=>2,key3=>3}', '{192.168.1.2,192.168.1.3}', '{2,3}', '{2,3}', '{2,3}', '{"{\"key2\": 2}","{\"key3\": 3}"}', '{0.2,0.3}', '{0.2,0.3}', '{Test,tEST}', '{00:02:00,00:03:00}', '{1999-02-01 00:00,1999-03-01 00:00}', '{1999-02-01 00:00,1999-03-01 00:00}', '{00:02:00,00:03:00}', '{00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000003}', '{0010,0011}', '{Test,tEST}'),
-  (3, '{0011,0100}', '{false,false}', '{tEST,test}', '{tEST,test}', '{tEST,test}', '{1999-03-01,1999-04-01}', '{0.3,0.4}', '{0.3,0.4}', '{key3=>3,key4=>4}', '{192.168.1.3,192.168.1.4}', '{3,4}', '{3,4}', '{3,4}', '{"{\"key3\": 3}","{\"key4\": 4}"}', '{0.3,0.4}', '{0.3,0.4}', '{tEST,test}', '{00:03:00,00:04:00}', '{1999-03-01 00:00,1999-04-01 00:00}', '{1999-03-01 00:00,1999-04-01 00:00}', '{00:03:00,00:04:00}', '{00000000-0000-0000-0000-000000000003,00000000-0000-0000-0000-000000000004}', '{0011,0100}', '{tEST,test}'),
-  (4, '{0100,0101}', '{false,false}', '{test,zest}', '{test,zest}', '{test,zest}', '{1999-04-01,1999-05-01}', '{0.4,0.5}', '{0.4,0.5}', '{key4=>4,key5=>5}', '{192.168.1.4,192.168.1.5}', '{4,5}', '{4,5}', '{4,5}', '{"{\"key4\": 4}","{\"key5\": 5}"}', '{0.4,0.5}', '{0.4,0.5}', '{test,zest}', '{00:04:00,00:05:00}', '{1999-04-01 00:00,1999-05-01 00:00}', '{1999-04-01 00:00,1999-05-01 00:00}', '{00:04:00,00:05:00}', '{00000000-0000-0000-0000-000000000004,00000000-0000-0000-0000-000000000005}', '{0100,0101}', '{test,zest}'),
-  (5, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+  (id, "bit4_array",  "bool_array",    "bpchar4_array", "char4_array", "citext_array", "date_array",              "float4_array", "float8_array", "hstore_array",      "inet_array",                 "int2_array", "int4_array", "int8_array", "jsonb_array",                       "money_array", "numeric_array", "text_array",  "time_array",          "timestamp_array",                     "timestamptz_array",                   "timetz_array",        "uuid_array", "varbit_array", "varchar_array") values
+  (1,  '{0001,0010}', '{false,true}',  '{TEST,Test}',   '{TEST,Test}', '{TEST,Test}',  '{1999-01-01,1999-02-01}', '{0.1,0.2}',    '{0.1,0.2}',    '{key1=>1,key2=>2}', '{192.168.1/24,192.168.1.2}', '{1,2}',      '{1,2}',      '{1,2}',      '{"{\"key1\": 1}","{\"key2\": 2}"}', '{0.1,0.2}',   '{0.1,0.2}',     '{TEST,Test}', '{00:01:00,00:02:00}', '{1999-01-01 00:00,1999-02-01 00:00}', '{1999-01-01 00:00,1999-02-01 00:00}', '{00:01:00,00:02:00}', '{00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000002}', '{0001,0010}',  '{TEST,Test}'),
+  (2,  '{0010,0011}', '{true,false}',  '{Test,tEST}',   '{Test,tEST}', '{Test,tEST}',  '{1999-02-01,1999-03-01}', '{0.2,0.3}',    '{0.2,0.3}',    '{key2=>2,key3=>3}', '{192.168.1.2,192.168.1.3}',  '{2,3}',      '{2,3}',      '{2,3}',      '{"{\"key2\": 2}","{\"key3\": 3}"}', '{0.2,0.3}',   '{0.2,0.3}',     '{Test,tEST}', '{00:02:00,00:03:00}', '{1999-02-01 00:00,1999-03-01 00:00}', '{1999-02-01 00:00,1999-03-01 00:00}', '{00:02:00,00:03:00}', '{00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000003}', '{0010,0011}',  '{Test,tEST}'),
+  (3,  '{0011,0100}', '{false,false}', '{tEST,test}',   '{tEST,test}', '{tEST,test}',  '{1999-03-01,1999-04-01}', '{0.3,0.4}',    '{0.3,0.4}',    '{key3=>3,key4=>4}', '{192.168.1.3,192.168.1.4}',  '{3,4}',      '{3,4}',      '{3,4}',      '{"{\"key3\": 3}","{\"key4\": 4}"}', '{0.3,0.4}',   '{0.3,0.4}',     '{tEST,test}', '{00:03:00,00:04:00}', '{1999-03-01 00:00,1999-04-01 00:00}', '{1999-03-01 00:00,1999-04-01 00:00}', '{00:03:00,00:04:00}', '{00000000-0000-0000-0000-000000000003,00000000-0000-0000-0000-000000000004}', '{0011,0100}',  '{tEST,test}'),
+  (4,  '{0100,0101}', '{false,false}', '{test,zest}',   '{test,zest}', '{test,zest}',  '{1999-04-01,1999-05-01}', '{0.4,0.5}',    '{0.4,0.5}',    '{key4=>4,key5=>5}', '{192.168.1.4,192.168.1.5}',  '{4,5}',      '{4,5}',      '{4,5}',      '{"{\"key4\": 4}","{\"key5\": 5}"}', '{0.4,0.5}',   '{0.4,0.5}',     '{test,zest}', '{00:04:00,00:05:00}', '{1999-04-01 00:00,1999-05-01 00:00}', '{1999-04-01 00:00,1999-05-01 00:00}', '{00:04:00,00:05:00}', '{00000000-0000-0000-0000-000000000004,00000000-0000-0000-0000-000000000005}', '{0100,0101}',  '{test,zest}'),
+  (5,  null,          null,            null,            null,          null,           null,                      null,           null,           null,                null,                         null,         null,         null,         null,                                null,          null,            null,          null,                  null,                                  null,                                  null,                  null,                                                                          null,           null);
 
 insert into p.range_types
-  (id, "date_range", "int4_range", "int8_range", "numeric_range", "timestamp_range", "timestamptz_range")
-values
-  (1, '[1999-01-01, 1999-02-01)', '[1,2)', '[1,2)', '[1,2)', '[1999-01-01 00:00, 1999-02-01 00:00)', '[1999-01-01 00:00, 1999-02-01 00:00)'),
-  (2, '[1999-02-01, 1999-03-01)', '[2,3)', '[2,3)', '[2,3)', '[1999-02-01 00:00, 1999-03-01 00:00)', '[1999-02-01 00:00, 1999-03-01 00:00)'),
-  (3, '[1999-03-01, 1999-04-01)', '[3,4)', '[3,4)', '[3,4)', '[1999-03-01 00:00, 1999-04-01 00:00)', '[1999-03-01 00:00, 1999-04-01 00:00)'),
-  (4, '[1999-04-01, 1999-05-01)', '[4,5)', '[4,5)', '[4,5)', '[1999-04-01 00:00, 1999-05-01 00:00)', '[1999-04-01 00:00, 1999-05-01 00:00)'),
-  (5, null, null, null, null, null, null);
+  (id, "date_range",               "int4_range", "int8_range", "numeric_range", "timestamp_range",                      "timestamptz_range") values
+  (1,  '[1999-01-01, 1999-02-01)', '[1,2)',      '[1,2)',      '[1,2)',         '[1999-01-01 00:00, 1999-02-01 00:00)', '[1999-01-01 00:00, 1999-02-01 00:00)'),
+  (2,  '[1999-02-01, 1999-03-01)', '[2,3)',      '[2,3)',      '[2,3)',         '[1999-02-01 00:00, 1999-03-01 00:00)', '[1999-02-01 00:00, 1999-03-01 00:00)'),
+  (3,  '[1999-03-01, 1999-04-01)', '[3,4)',      '[3,4)',      '[3,4)',         '[1999-03-01 00:00, 1999-04-01 00:00)', '[1999-03-01 00:00, 1999-04-01 00:00)'),
+  (4,  '[1999-04-01, 1999-05-01)', '[4,5)',      '[4,5)',      '[4,5)',         '[1999-04-01 00:00, 1999-05-01 00:00)', '[1999-04-01 00:00, 1999-05-01 00:00)'),
+  (5,  null,                       null,         null,         null,            null,                                   null);
 
 insert into p.domain_types
-  (id, char4_domain, date_domain, int4_domain)
-values
+  (id, char4_domain, date_domain, int4_domain) values
   (1, 'TEST', '1999-01-01', 1),
   (2, 'Test', '1999-02-01', 2),
   (3, 'tEST', '1999-03-01', 3),
   (4, 'test', '1999-04-01', 4),
-  (5, null, null, null);
+  (5, null,   null,         null);
 
 insert into p.enum_types
-  (id, "enum")
-values
-  (1, 'sad'),
-  (2, 'ok'),
-  (3, 'happy'),
-  (4, 'happy'),
-  (5, null);
+  (id, "enum") values
+  (1,  'sad'),
+  (2,  'ok'),
+  (3,  'happy'),
+  (4,  'happy'),
+  (5,  null);
 
-insert into p.jsonb_test
-  (id, jsonb_with_array, jsonb_with_object)
-values
+insert into p.jsonb_test (id, jsonb_with_array, jsonb_with_object) values
   (1, '[{"key1":1},{"key2":2}]', '{"key1":1}'),
   (2, '[{"key2":2},{"key3":3}]', '{"key2":2}'),
   (3, '[{"key3":3},{"key4":4}]', '{"key3":3}'),
   (4, '[{"key4":4},{"key5":5}]', '{"key4":4}'),
   (5, null, null);
 
-insert into p.backward
-  (id, name, filterable_id)
-values
+insert into p.backward(id, name, filterable_id) values
   (1, 'backward1', 1),
   (2, 'backward2', 2),
   (3, 'backward3', 3),
   (4, 'backward4', 4);
 
-insert into p.backward_compound
-  (backward_compound_1, backward_compound_2, name)
-values
+insert into p.backward_compound(backward_compound_1, backward_compound_2, name) values
   (1, 1, 'backwardCompound11'),
   (1, 2, 'backwardCompound12'),
   (2, 1, 'backwardCompound21'),
   (2, 2, 'backwardCompound22');
 
-insert into p.child
-  (id, name, filterable_id)
-values
+insert into p.child(id, name, filterable_id) values
   (1, 'child1', 1),
   (2, 'child2', 1),
   (3, 'child3', 2),
   (4, 'child4', 2);
 
-insert into p.side_a
-  (a_id, name)
-values
+insert into p.side_a(a_id, name) values
   (11, 'a11'),
   (12, 'a12'),
   (13, 'a13');
 
-insert into p.side_b
-  (b_id, name)
-values
+insert into p.side_b(b_id, name) values
   (21, 'b21'),
   (22, 'b22'),
   (23, 'b23');
 
-insert into p.junction
-  (side_a_id, side_b_id)
-values
+insert into p.junction(side_a_id, side_b_id) values
   (11, 21),
   (11, 22),
   (12, 21);
 
-insert into p.filterable_closure
-  (ancestor_id, descendant_id, depth)
-values
+insert into p.filterable_closure (ancestor_id, descendant_id, depth) values
   (1, 1, 0),
   (2, 2, 0),
   (3, 3, 0),

--- a/__tests__/p-data.sql
+++ b/__tests__/p-data.sql
@@ -1,108 +1,140 @@
-insert into p.parent(id, name) values
+insert into p.parent
+  (id, name)
+values
   (1, 'parent1'),
   (2, 'parent2');
 
-insert into p.taggs(id,taggable_id,taggable_type,content) values 
-(1,1,'Parent','tagged on parent1'),
-(2,2,'Parent','tagged on parent2');
+insert into p.taggs
+  (id,taggable_id,taggable_type,content)
+values
+  (1, 1, 'Parent', 'tagged on parent1'),
+  (2, 2, 'Parent', 'tagged on parent2');
 
-insert into p.unique_taggs(id,taggable_id,taggable_type,content) values 
-(1,1,'Parent','unique tagged on parent1'),
-(2,2,'Forward','unique tagged on forward2');
+insert into p.unique_taggs
+  (id,unique_taggable_id,unique_taggable_type,content)
+values
+  (1, 1, 'Parent', 'unique tagged on parent1'),
+  (2, 2, 'Forward', 'unique tagged on forward2');
 
-insert into p.forward(id, name) values
+insert into p.forward
+  (id, name)
+values
   (1, 'forward1'),
   (2, 'forward2'),
   (3, 'forward3'),
   (4, 'forward4');
 
-insert into p.forward_compound(forward_compound_1, forward_compound_2, name) values
+insert into p.forward_compound
+  (forward_compound_1, forward_compound_2, name)
+values
   (1, 1, 'forwardCompound11'),
   (1, 2, 'forwardCompound12'),
   (2, 1, 'forwardCompound21'),
   (2, 2, 'forwardCompound22');
 
 insert into p.filterable
-  (id, "bit4",  "bool", "bpchar4", "bytea", "char4", "cidr", "citext", "date",       "float4", "float8", "hstore",  "inet",         "int2", "int4", "int8", "interval",       "json", "jsonb",      "macaddr", "money", "name", "numeric", "text", "time",     "timestamp",        "timestamptz",      "timetz",   "uuid",                                 "varbit", "varchar", "xml", "parent_id", "forward_id", "forward_compound_1", "forward_compound_2", "backward_compound_1", "backward_compound_2") values
-  (1,  B'0001', false,  'TEST',    '\x01',  'TEST',  null,   'TEST',   '1999-01-01', 0.1,      0.1,      'key1=>1', '192.168.1/24', 1,      1,      1,      'P0Y0M1DT0H0M0S', null,   '{"key1":1}', null,      0.1,     'TEST', 0.1,       'TEST', '00:01:00', '1999-01-01 00:00', '1999-01-01 00:00', '00:01:00', '00000000-0000-0000-0000-000000000001', B'0001',  'TEST',    null,  1,           1,            1,                    1,                    1,                     1),
-  (2,  B'0010', true,   'Test',    '\x02',  'Test',  null,   'Test',   '1999-02-01', 0.2,      0.2,      'key2=>2', '192.168.1.2',  2,      2,      2,      'P0Y0M2DT0H0M0S', null,   '{"key2":2}', null,      0.2,     'Test', 0.2,       'Test', '00:02:00', '1999-02-01 00:00', '1999-02-01 00:00', '00:02:00', '00000000-0000-0000-0000-000000000002', B'0010',  'Test',    null,  1,           2,            1,                    2,                    1,                     2),
-  (3,  B'0011', false,  'tEST',    '\x03',  'tEST',  null,   'tEST',   '1999-03-01', 0.3,      0.3,      'key3=>3', '192.168.1.3',  3,      3,      3,      'P0Y0M3DT0H0M0S', null,   '{"key3":3}', null,      0.3,     'tEST', 0.3,       'tEST', '00:03:00', '1999-03-01 00:00', '1999-03-01 00:00', '00:03:00', '00000000-0000-0000-0000-000000000003', B'0011',  'tEST',    null,  2,           3,            2,                    1,                    2,                     1),
-  (4,  B'0100', false,  'test',    '\x04',  'test',  null,   'test',   '1999-04-01', 0.4,      0.4,      'key4=>4', '192.168.1.4',  4,      4,      4,      'P0Y0M4DT0H0M0S', null,   '{"key4":4}', null,      0.4,     'test', 0.4,       'test', '00:04:00', '1999-04-01 00:00', '1999-04-01 00:00', '00:04:00', '00000000-0000-0000-0000-000000000004', B'0100',  'test',    null,  2,           4,            2,                    2,                    2,                     2),
-  (5,  null,    null,   null,      null,    null,    null,   null,     null,         null,     null,     null,      null,           null,   null,   null,   null,             null,   null,         null,      null,    null,   null,      null,   null,       null,               null,               null,       null,                                   null,     null,      null,  null,        null,         null,                 null,                 null,                  null);
+  (id, "bit4", "bool", "bpchar4", "bytea", "char4", "cidr", "citext", "date", "float4", "float8", "hstore", "inet", "int2", "int4", "int8", "interval", "json", "jsonb", "macaddr", "money", "name", "numeric", "text", "time", "timestamp", "timestamptz", "timetz", "uuid", "varbit", "varchar", "xml", "parent_id", "forward_id", "forward_compound_1", "forward_compound_2", "backward_compound_1", "backward_compound_2")
+values
+  (1, B'0001', false, 'TEST', '\x01', 'TEST', null, 'TEST', '1999-01-01', 0.1, 0.1, 'key1=>1', '192.168.1/24', 1, 1, 1, 'P0Y0M1DT0H0M0S', null, '{"key1":1}', null, 0.1, 'TEST', 0.1, 'TEST', '00:01:00', '1999-01-01 00:00', '1999-01-01 00:00', '00:01:00', '00000000-0000-0000-0000-000000000001', B
+'0001',  'TEST',    null,  1,           1,            1,                    1,                    1,                     1),
+(2,  B'0010', true,   'Test',    '\x02',  'Test',  null,   'Test',   '1999-02-01', 0.2,      0.2,      'key2=>2', '192.168.1.2',  2,      2,      2,      'P0Y0M2DT0H0M0S', null,   '{"key2":2}', null,      0.2,     'Test', 0.2,       'Test', '00:02:00', '1999-02-01 00:00', '1999-02-01 00:00', '00:02:00', '00000000-0000-0000-0000-000000000002', B'0010',  'Test',    null,  1,           2,            1,                    2,                    1,                     2),
+(3,  B'0011', false,  'tEST',    '\x03',  'tEST',  null,   'tEST',   '1999-03-01', 0.3,      0.3,      'key3=>3', '192.168.1.3',  3,      3,      3,      'P0Y0M3DT0H0M0S', null,   '{"key3":3}', null,      0.3,     'tEST', 0.3,       'tEST', '00:03:00', '1999-03-01 00:00', '1999-03-01 00:00', '00:03:00', '00000000-0000-0000-0000-000000000003', B'0011',  'tEST',    null,  2,           3,            2,                    1,                    2,                     1),
+(4,  B'0100', false,  'test',    '\x04',  'test',  null,   'test',   '1999-04-01', 0.4,      0.4,      'key4=>4', '192.168.1.4',  4,      4,      4,      'P0Y0M4DT0H0M0S', null,   '{"key4":4}', null,      0.4,     'test', 0.4,       'test', '00:04:00', '1999-04-01 00:00', '1999-04-01 00:00', '00:04:00', '00000000-0000-0000-0000-000000000004', B'0100',  'test',    null,  2,           4,            2,                    2,                    2,                     2),
+(5,  null,    null,   null,      null,    null,    null,   null,     null,         null,     null,     null,      null,           null,   null,   null,   null,             null,   null,         null,      null,    null,   null,      null,   null,       null,               null,               null,       null,                                   null,     null,      null,  null,        null,         null,                 null,                 null,                  null);
 
 insert into p.array_types
-  (id, "bit4_array",  "bool_array",    "bpchar4_array", "char4_array", "citext_array", "date_array",              "float4_array", "float8_array", "hstore_array",      "inet_array",                 "int2_array", "int4_array", "int8_array", "jsonb_array",                       "money_array", "numeric_array", "text_array",  "time_array",          "timestamp_array",                     "timestamptz_array",                   "timetz_array",        "uuid_array", "varbit_array", "varchar_array") values
-  (1,  '{0001,0010}', '{false,true}',  '{TEST,Test}',   '{TEST,Test}', '{TEST,Test}',  '{1999-01-01,1999-02-01}', '{0.1,0.2}',    '{0.1,0.2}',    '{key1=>1,key2=>2}', '{192.168.1/24,192.168.1.2}', '{1,2}',      '{1,2}',      '{1,2}',      '{"{\"key1\": 1}","{\"key2\": 2}"}', '{0.1,0.2}',   '{0.1,0.2}',     '{TEST,Test}', '{00:01:00,00:02:00}', '{1999-01-01 00:00,1999-02-01 00:00}', '{1999-01-01 00:00,1999-02-01 00:00}', '{00:01:00,00:02:00}', '{00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000002}', '{0001,0010}',  '{TEST,Test}'),
-  (2,  '{0010,0011}', '{true,false}',  '{Test,tEST}',   '{Test,tEST}', '{Test,tEST}',  '{1999-02-01,1999-03-01}', '{0.2,0.3}',    '{0.2,0.3}',    '{key2=>2,key3=>3}', '{192.168.1.2,192.168.1.3}',  '{2,3}',      '{2,3}',      '{2,3}',      '{"{\"key2\": 2}","{\"key3\": 3}"}', '{0.2,0.3}',   '{0.2,0.3}',     '{Test,tEST}', '{00:02:00,00:03:00}', '{1999-02-01 00:00,1999-03-01 00:00}', '{1999-02-01 00:00,1999-03-01 00:00}', '{00:02:00,00:03:00}', '{00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000003}', '{0010,0011}',  '{Test,tEST}'),
-  (3,  '{0011,0100}', '{false,false}', '{tEST,test}',   '{tEST,test}', '{tEST,test}',  '{1999-03-01,1999-04-01}', '{0.3,0.4}',    '{0.3,0.4}',    '{key3=>3,key4=>4}', '{192.168.1.3,192.168.1.4}',  '{3,4}',      '{3,4}',      '{3,4}',      '{"{\"key3\": 3}","{\"key4\": 4}"}', '{0.3,0.4}',   '{0.3,0.4}',     '{tEST,test}', '{00:03:00,00:04:00}', '{1999-03-01 00:00,1999-04-01 00:00}', '{1999-03-01 00:00,1999-04-01 00:00}', '{00:03:00,00:04:00}', '{00000000-0000-0000-0000-000000000003,00000000-0000-0000-0000-000000000004}', '{0011,0100}',  '{tEST,test}'),
-  (4,  '{0100,0101}', '{false,false}', '{test,zest}',   '{test,zest}', '{test,zest}',  '{1999-04-01,1999-05-01}', '{0.4,0.5}',    '{0.4,0.5}',    '{key4=>4,key5=>5}', '{192.168.1.4,192.168.1.5}',  '{4,5}',      '{4,5}',      '{4,5}',      '{"{\"key4\": 4}","{\"key5\": 5}"}', '{0.4,0.5}',   '{0.4,0.5}',     '{test,zest}', '{00:04:00,00:05:00}', '{1999-04-01 00:00,1999-05-01 00:00}', '{1999-04-01 00:00,1999-05-01 00:00}', '{00:04:00,00:05:00}', '{00000000-0000-0000-0000-000000000004,00000000-0000-0000-0000-000000000005}', '{0100,0101}',  '{test,zest}'),
-  (5,  null,          null,            null,            null,          null,           null,                      null,           null,           null,                null,                         null,         null,         null,         null,                                null,          null,            null,          null,                  null,                                  null,                                  null,                  null,                                                                          null,           null);
+  (id, "bit4_array", "bool_array", "bpchar4_array", "char4_array", "citext_array", "date_array", "float4_array", "float8_array", "hstore_array", "inet_array", "int2_array", "int4_array", "int8_array", "jsonb_array", "money_array", "numeric_array", "text_array", "time_array", "timestamp_array", "timestamptz_array", "timetz_array", "uuid_array", "varbit_array", "varchar_array")
+values
+  (1, '{0001,0010}', '{false,true}', '{TEST,Test}', '{TEST,Test}', '{TEST,Test}', '{1999-01-01,1999-02-01}', '{0.1,0.2}', '{0.1,0.2}', '{key1=>1,key2=>2}', '{192.168.1/24,192.168.1.2}', '{1,2}', '{1,2}', '{1,2}', '{"{\"key1\": 1}","{\"key2\": 2}"}', '{0.1,0.2}', '{0.1,0.2}', '{TEST,Test}', '{00:01:00,00:02:00}', '{1999-01-01 00:00,1999-02-01 00:00}', '{1999-01-01 00:00,1999-02-01 00:00}', '{00:01:00,00:02:00}', '{00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000002}', '{0001,0010}', '{TEST,Test}'),
+  (2, '{0010,0011}', '{true,false}', '{Test,tEST}', '{Test,tEST}', '{Test,tEST}', '{1999-02-01,1999-03-01}', '{0.2,0.3}', '{0.2,0.3}', '{key2=>2,key3=>3}', '{192.168.1.2,192.168.1.3}', '{2,3}', '{2,3}', '{2,3}', '{"{\"key2\": 2}","{\"key3\": 3}"}', '{0.2,0.3}', '{0.2,0.3}', '{Test,tEST}', '{00:02:00,00:03:00}', '{1999-02-01 00:00,1999-03-01 00:00}', '{1999-02-01 00:00,1999-03-01 00:00}', '{00:02:00,00:03:00}', '{00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000003}', '{0010,0011}', '{Test,tEST}'),
+  (3, '{0011,0100}', '{false,false}', '{tEST,test}', '{tEST,test}', '{tEST,test}', '{1999-03-01,1999-04-01}', '{0.3,0.4}', '{0.3,0.4}', '{key3=>3,key4=>4}', '{192.168.1.3,192.168.1.4}', '{3,4}', '{3,4}', '{3,4}', '{"{\"key3\": 3}","{\"key4\": 4}"}', '{0.3,0.4}', '{0.3,0.4}', '{tEST,test}', '{00:03:00,00:04:00}', '{1999-03-01 00:00,1999-04-01 00:00}', '{1999-03-01 00:00,1999-04-01 00:00}', '{00:03:00,00:04:00}', '{00000000-0000-0000-0000-000000000003,00000000-0000-0000-0000-000000000004}', '{0011,0100}', '{tEST,test}'),
+  (4, '{0100,0101}', '{false,false}', '{test,zest}', '{test,zest}', '{test,zest}', '{1999-04-01,1999-05-01}', '{0.4,0.5}', '{0.4,0.5}', '{key4=>4,key5=>5}', '{192.168.1.4,192.168.1.5}', '{4,5}', '{4,5}', '{4,5}', '{"{\"key4\": 4}","{\"key5\": 5}"}', '{0.4,0.5}', '{0.4,0.5}', '{test,zest}', '{00:04:00,00:05:00}', '{1999-04-01 00:00,1999-05-01 00:00}', '{1999-04-01 00:00,1999-05-01 00:00}', '{00:04:00,00:05:00}', '{00000000-0000-0000-0000-000000000004,00000000-0000-0000-0000-000000000005}', '{0100,0101}', '{test,zest}'),
+  (5, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
 
 insert into p.range_types
-  (id, "date_range",               "int4_range", "int8_range", "numeric_range", "timestamp_range",                      "timestamptz_range") values
-  (1,  '[1999-01-01, 1999-02-01)', '[1,2)',      '[1,2)',      '[1,2)',         '[1999-01-01 00:00, 1999-02-01 00:00)', '[1999-01-01 00:00, 1999-02-01 00:00)'),
-  (2,  '[1999-02-01, 1999-03-01)', '[2,3)',      '[2,3)',      '[2,3)',         '[1999-02-01 00:00, 1999-03-01 00:00)', '[1999-02-01 00:00, 1999-03-01 00:00)'),
-  (3,  '[1999-03-01, 1999-04-01)', '[3,4)',      '[3,4)',      '[3,4)',         '[1999-03-01 00:00, 1999-04-01 00:00)', '[1999-03-01 00:00, 1999-04-01 00:00)'),
-  (4,  '[1999-04-01, 1999-05-01)', '[4,5)',      '[4,5)',      '[4,5)',         '[1999-04-01 00:00, 1999-05-01 00:00)', '[1999-04-01 00:00, 1999-05-01 00:00)'),
-  (5,  null,                       null,         null,         null,            null,                                   null);
+  (id, "date_range", "int4_range", "int8_range", "numeric_range", "timestamp_range", "timestamptz_range")
+values
+  (1, '[1999-01-01, 1999-02-01)', '[1,2)', '[1,2)', '[1,2)', '[1999-01-01 00:00, 1999-02-01 00:00)', '[1999-01-01 00:00, 1999-02-01 00:00)'),
+  (2, '[1999-02-01, 1999-03-01)', '[2,3)', '[2,3)', '[2,3)', '[1999-02-01 00:00, 1999-03-01 00:00)', '[1999-02-01 00:00, 1999-03-01 00:00)'),
+  (3, '[1999-03-01, 1999-04-01)', '[3,4)', '[3,4)', '[3,4)', '[1999-03-01 00:00, 1999-04-01 00:00)', '[1999-03-01 00:00, 1999-04-01 00:00)'),
+  (4, '[1999-04-01, 1999-05-01)', '[4,5)', '[4,5)', '[4,5)', '[1999-04-01 00:00, 1999-05-01 00:00)', '[1999-04-01 00:00, 1999-05-01 00:00)'),
+  (5, null, null, null, null, null, null);
 
 insert into p.domain_types
-  (id, char4_domain, date_domain, int4_domain) values
+  (id, char4_domain, date_domain, int4_domain)
+values
   (1, 'TEST', '1999-01-01', 1),
   (2, 'Test', '1999-02-01', 2),
   (3, 'tEST', '1999-03-01', 3),
   (4, 'test', '1999-04-01', 4),
-  (5, null,   null,         null);
+  (5, null, null, null);
 
 insert into p.enum_types
-  (id, "enum") values
-  (1,  'sad'),
-  (2,  'ok'),
-  (3,  'happy'),
-  (4,  'happy'),
-  (5,  null);
+  (id, "enum")
+values
+  (1, 'sad'),
+  (2, 'ok'),
+  (3, 'happy'),
+  (4, 'happy'),
+  (5, null);
 
-insert into p.jsonb_test (id, jsonb_with_array, jsonb_with_object) values
+insert into p.jsonb_test
+  (id, jsonb_with_array, jsonb_with_object)
+values
   (1, '[{"key1":1},{"key2":2}]', '{"key1":1}'),
   (2, '[{"key2":2},{"key3":3}]', '{"key2":2}'),
   (3, '[{"key3":3},{"key4":4}]', '{"key3":3}'),
   (4, '[{"key4":4},{"key5":5}]', '{"key4":4}'),
   (5, null, null);
 
-insert into p.backward(id, name, filterable_id) values
+insert into p.backward
+  (id, name, filterable_id)
+values
   (1, 'backward1', 1),
   (2, 'backward2', 2),
   (3, 'backward3', 3),
   (4, 'backward4', 4);
 
-insert into p.backward_compound(backward_compound_1, backward_compound_2, name) values
+insert into p.backward_compound
+  (backward_compound_1, backward_compound_2, name)
+values
   (1, 1, 'backwardCompound11'),
   (1, 2, 'backwardCompound12'),
   (2, 1, 'backwardCompound21'),
   (2, 2, 'backwardCompound22');
 
-insert into p.child(id, name, filterable_id) values
+insert into p.child
+  (id, name, filterable_id)
+values
   (1, 'child1', 1),
   (2, 'child2', 1),
   (3, 'child3', 2),
   (4, 'child4', 2);
 
-insert into p.side_a(a_id, name) values
+insert into p.side_a
+  (a_id, name)
+values
   (11, 'a11'),
   (12, 'a12'),
   (13, 'a13');
 
-insert into p.side_b(b_id, name) values
+insert into p.side_b
+  (b_id, name)
+values
   (21, 'b21'),
   (22, 'b22'),
   (23, 'b23');
 
-insert into p.junction(side_a_id, side_b_id) values
+insert into p.junction
+  (side_a_id, side_b_id)
+values
   (11, 21),
   (11, 22),
   (12, 21);
 
-insert into p.filterable_closure (ancestor_id, descendant_id, depth) values
+insert into p.filterable_closure
+  (ancestor_id, descendant_id, depth)
+values
   (1, 1, 0),
   (2, 2, 0),
   (3, 3, 0),

--- a/__tests__/p-schema.sql
+++ b/__tests__/p-schema.sql
@@ -1,11 +1,15 @@
-create extension if not exists hstore;
-create extension if not exists citext;
+create extension
+if not exists hstore;
+create extension
+if not exists citext;
 
-drop schema if exists p cascade;
+drop schema if exists p
+cascade;
 
 create schema p;
 
-create table p.taggs (
+create table p.taggs
+(
   id serial primary key,
   "taggable_id" integer not null,
   "taggable_type" text not null,
@@ -13,45 +17,54 @@ create table p.taggs (
 );
 comment on column p.taggs.taggable_type is E'@isPolymorphic\n@polymorphicTo Parent\n@polymorphicTo Forward\n@polymorphicTo ForwardCompound';
 
-create table p.unique_taggs (
+create table p.unique_taggs
+(
   id serial primary key,
-  "taggable_id" integer not null,
-  "taggable_type" text not null,
+  "unique_taggable_id" integer not null,
+  "unique_taggable_type" text not null,
   "content" text
 );
 
 comment on column p.unique_taggs.taggable_type is E'@isPolymorphic\n@polymorphicTo Parent\n@polymorphicTo Forward';
 alter table p.unique_taggs add constraint unique_tag_type_is_unique UNIQUE (taggable_id,taggable_type);
 
-create table p.parent (
+create table p.parent
+(
   id serial primary key,
   "name" text not null
 );
 
-create table p.forward (
+create table p.forward
+(
   id serial primary key,
   "name" text not null
 );
 
-create table p.forward_compound (
+create table p.forward_compound
+(
   forward_compound_1 int,
   forward_compound_2 int,
   "name" text,
   primary key ("forward_compound_1", "forward_compound_2")
 );
 
-create type p.mood as enum ('sad', 'ok', 'happy');
+create type p.mood as enum
+('sad', 'ok', 'happy');
 
-create type p."composite" as (a int, b text);
+create type p."composite" as
+(a int, b text);
 
-create table p.filterable (
+create table p.filterable
+(
   id serial primary key,
   "bit4" bit(4),
   "bool" bool,
   "bpchar4" bpchar(4),
-  "bytea" bytea, -- treated as String in PostGraphile v4
+  "bytea" bytea,
+  -- treated as String in PostGraphile v4
   "char4" char(4),
-  "cidr" cidr, -- treated as String in PostGraphile v4
+  "cidr" cidr,
+  -- treated as String in PostGraphile v4
   "citext" citext,
   "date" date,
   "float4" float4,
@@ -62,9 +75,11 @@ create table p.filterable (
   "int4" int4,
   "int8" int8,
   "interval" interval,
-  "json" json, -- not filterable
+  "json" json,
+  -- not filterable
   "jsonb" jsonb,
-  "macaddr" macaddr, -- treated as String in PostGraphile v4
+  "macaddr" macaddr,
+  -- treated as String in PostGraphile v4
   --"macaddr8" macaddr8, -- treated as String in PostGraphile v4; excluded because macaddr8 requires PG10+
   "money" money,
   "name" name,
@@ -77,10 +92,14 @@ create table p.filterable (
   "uuid" uuid,
   "varbit" varbit,
   "varchar" varchar,
-  "xml" xml, -- not filterable
-  "composite_column" p."composite", -- not filterable
-  "forward_column" p.forward, -- not filterable
-  "text_omit_filter" text, -- not filterable
+  "xml" xml,
+  -- not filterable
+  "composite_column" p."composite",
+  -- not filterable
+  "forward_column" p.forward,
+  -- not filterable
+  "text_omit_filter" text,
+  -- not filterable
   "parent_id" int references p.parent (id),
   "forward_id" int unique references p.forward (id),
   "forward_compound_1" int,
@@ -94,13 +113,17 @@ create table p.filterable (
 
 comment on column p.filterable."text_omit_filter" is E'@omit filter';
 
-create table p.array_types (
+create table p.array_types
+(
   id serial primary key,
-  "bit4_array" bit(4)[],
+  "bit4_array" bit(4)
+  [],
   "bool_array" bool[],
-  "bpchar4_array" bpchar(4)[],
+  "bpchar4_array" bpchar
+  (4)[],
   "bytea_array" bytea[],
-  "char4_array" char(4)[],
+  "char4_array" char
+  (4)[],
   "cidr_array" cidr[],
   "citext_array" citext[],
   "date_array" date[],
@@ -129,19 +152,22 @@ create table p.array_types (
   "xml_array" xml[] -- not filterable
 );
 
-create table p.range_types (
-  id serial primary key,
-  "date_range" daterange,
-  "int4_range" int4range,
-  "int8_range" int8range,
-  "numeric_range" numrange,
-  "timestamp_range" tsrange,
-  "timestamptz_range" tstzrange
-);
+  create table p.range_types
+  (
+    id serial primary key,
+    "date_range" daterange,
+    "int4_range" int4range,
+    "int8_range" int8range,
+    "numeric_range" numrange,
+    "timestamp_range" tsrange,
+    "timestamptz_range" tstzrange
+  );
 
-create table p.range_array_types (
-  id serial primary key,
-  "date_range_array" daterange[],
+  create table p.range_array_types
+  (
+    id serial primary key,
+    "date_range_array" daterange
+    [],
   "int4_range_array" int4range[],
   "int8_range_array" int8range[],
   "numeric_range_array" numrange[],
@@ -149,172 +175,208 @@ create table p.range_array_types (
   "timestamptz_range_array" tstzrange[]
 );
 
-create domain p.char4_domain as char(4) check (lower(value) = 'test');
-create domain p.date_domain as date check (value >= '1990-01-01'::date);
-create domain p.int4_domain as int4 check (value > 0);
+    create domain p.char4_domain as char
+    (4) check
+    (lower
+    (value) = 'test');
+    create domain p.date_domain as date check
+    (value >= '1990-01-01'::date);
+    create domain p.int4_domain as int4 check
+    (value > 0);
 
-create table p.domain_types (
-  id serial primary key,
-  "char4_domain" p.char4_domain,
-  "date_domain" p.date_domain,
-  "int4_domain" p.int4_domain  
+    create table p.domain_types
+    (
+      id serial primary key,
+      "char4_domain" p.char4_domain,
+      "date_domain" p.date_domain,
+      "int4_domain" p.int4_domain
+    );
+
+    create table p.enum_types
+    (
+      id serial primary key,
+      "enum" p.mood
+    );
+
+    create table p.enum_array_types
+    (
+      id serial primary key,
+      "enum_array" p.mood
+      []
 );
 
-create table p.enum_types (
-  id serial primary key,
-  "enum" p.mood
-);
+      create table p.jsonb_test
+      (
+        id serial primary key,
+        jsonb_with_array jsonb,
+        jsonb_with_object jsonb
+      );
 
-create table p.enum_array_types (
-  id serial primary key,
-  "enum_array" p.mood[]
-);
+      create table p.backward
+      (
+        id serial primary key,
+        "name" text not null,
+        "filterable_id" int unique references p.filterable (id)
+      );
 
-create table p.jsonb_test (
-  id serial primary key,
-  jsonb_with_array jsonb,
-  jsonb_with_object jsonb
-);
+      create table p.backward_compound
+      (
+        backward_compound_1 int,
+        backward_compound_2 int,
+        "name" text,
+        primary key ("backward_compound_1", "backward_compound_2"),
+        foreign key ("backward_compound_1", "backward_compound_2") references p.filterable ("backward_compound_1", "backward_compound_2")
+      );
 
-create table p.backward (
-  id serial primary key,
-  "name" text not null,
-  "filterable_id" int unique references p.filterable (id)
-);
+      create table p.child
+      (
+        id serial primary key,
+        "name" text not null,
+        "filterable_id" int references p.filterable (id)
+      );
 
-create table p.backward_compound (
-  backward_compound_1 int,
-  backward_compound_2 int,
-  "name" text,
-  primary key ("backward_compound_1", "backward_compound_2"),
-  foreign key ("backward_compound_1", "backward_compound_2") references p.filterable ("backward_compound_1", "backward_compound_2")
-);
+      create table p."side_a"
+      (
+        a_id integer primary key,
+        name text not null
+      );
 
-create table p.child (
-  id serial primary key,
-  "name" text not null,
-  "filterable_id" int references p.filterable (id)
-);
+      create table p."side_b"
+      (
+        b_id integer primary key,
+        name text not null
+      );
 
-create table p."side_a" (
-  a_id integer primary key,
-  name text not null
-);
+      create table p."junction"
+      (
+        side_a_id integer not null references p."side_a" (a_id),
+        side_b_id integer not null references p."side_b" (b_id),
+        primary key (side_a_id, side_b_id)
+      );
 
-create table p."side_b" (
-  b_id integer primary key,
-  name text not null
-);
+      create table p.unfilterable
+      (
+        id serial primary key,
+        "text" text
+      );
 
-create table p."junction" (
-  side_a_id integer not null references p."side_a" (a_id),
-  side_b_id integer not null references p."side_b" (b_id),
-  primary key (side_a_id, side_b_id)
-);
+      comment on table p.unfilterable is E'@omit filter';
 
-create table p.unfilterable (
-  id serial primary key,
-  "text" text
-);
+      create table p.fully_omitted
+      (
+        id serial primary key,
+        "text" text
+      );
 
-comment on table p.unfilterable is E'@omit filter';
-
-create table p.fully_omitted (
-  id serial primary key,
-  "text" text
-);
-
-comment on column p.fully_omitted.id is '@omit filter';
+      comment on column p.fully_omitted.id is '@omit filter';
 comment on column p.fully_omitted."text" is '@omit filter';
 
-create function p.filterable_computed(filterable p.filterable) returns text as $$
-  select filterable."text" || ' computed'
-$$ language sql stable;
+      create function p.filterable_computed(filterable p.filterable) returns text as $$
+      select filterable."text" || ' computed'
+      $$ language sql stable;
 
-create function p.filterable_computed2(filterable p.filterable) returns text as $$
-  select filterable."text" || ' computed2'
-$$ language sql stable;
+      create function p.filterable_computed2(filterable p.filterable) returns text as $$
+      select filterable."text" || ' computed2'
+      $$ language sql stable;
 
-comment on function p.filterable_computed2(p.filterable) is E'@omit filter';
+comment on function p.filterable_computed2
+      (p.filterable) is E'@omit filter';
 
-create function p.filterable_computed_int_array(f p.filterable) returns int[] as $$
-  select
-    case
+      create function p.filterable_computed_int_array(f p.filterable) returns int[] as $$
+      select
+        case
       when f.id = 1 then array[1, 10]
       when f.id = 2 then array[2, 20]
       when f.id = 3 then array[3, 30]
       when f.id = 4 then array[4, 40]
       else null
     end;
+      $$ language sql stable;
+
+      create function p.filterable_computed_setof_int(f p.filterable) returns setof int as $$
+  values
+      (42),
+      (43);
 $$ language sql stable;
 
-create function p.filterable_computed_setof_int(f p.filterable) returns setof int as $$
-  values (42), (43);
+      create function p.filterable_computed_child(f p.filterable) returns p.child as $$
+      select p.child.*
+      from p.child
+      where filterable_id = f.id
+      limit 1;
 $$ language sql stable;
 
-create function p.filterable_computed_child(f p.filterable) returns p.child as $$
-  select p.child.*
-  from p.child
-  where filterable_id = f.id
-  limit 1;
-$$ language sql stable;
+      create function p.filterable_computed_setof_child(f p.filterable) returns setof p.child as $$
+      select p.child.*
+      from p.child
+      where filterable_id = f.id;
+      $$ language sql stable;
 
-create function p.filterable_computed_setof_child(f p.filterable) returns setof p.child as $$
-  select p.child.*
-  from p.child
-  where filterable_id = f.id;
-$$ language sql stable;
+      create function p.func_returns_table_one_col(i int) returns table
+      (col1 int) as $$
+              select i + 42 as col1
+      union
+        select i + 43 as col1;
+      $$ language sql stable;
 
-create function p.func_returns_table_one_col(i int) returns table (col1 int) as $$
-  select i + 42 as col1
+      create function p.func_returns_table_multi_col(i int) returns table
+      (col1 int, col2 text) as $$
+      select i + 42 as col1, 'out'
+      ::text as col2
   union
-  select i + 43 as col1;
+      select i + 43 as col1, 'out2'
+      ::text as col2;
 $$ language sql stable;
 
-create function p.func_returns_table_multi_col(i int) returns table (col1 int, col2 text) as $$
-  select i + 42 as col1, 'out'::text as col2
+      -- @filterable smart comments
+
+      create function p.filterable_computed_tagged_filterable(filterable p.filterable) returns int as $$
+      select 42;
+      $$ language sql stable;
+
+comment on function p.filterable_computed_tagged_filterable
+      (filterable p.filterable) is E'@filterable';
+
+      create function p.func_tagged_filterable_returns_setof_filterable() returns setof p.filterable as $$
+      select *
+      from p.filterable;
+      $$ language sql stable;
+
+comment on function p.func_tagged_filterable_returns_setof_filterable
+      () is E'@filterable';
+
+      create function p.func_tagged_filterable_returns_table_multi_col() returns table (col1 int,
+        col2 text) as $$
+      select 42 as col1, 'out'
+      ::text as col2
   union
-  select i + 43 as col1, 'out2'::text as col2;
+      select 43 as col1, 'out2'
+      ::text as col2;
 $$ language sql stable;
 
--- @filterable smart comments
+comment on function p.func_tagged_filterable_returns_table_multi_col
+      () is E'@filterable';
 
-create function p.filterable_computed_tagged_filterable(filterable p.filterable) returns int as $$
-  select 42;
-$$ language sql stable;
+      create table p.protected
+      (
+        id int primary key,
+        other_id int,
+        name text
+      );
 
-comment on function p.filterable_computed_tagged_filterable (filterable p.filterable) is E'@filterable';
+      comment on table p.protected is E'@omit all';
 
-create function p.func_tagged_filterable_returns_setof_filterable() returns setof p.filterable as $$
-  select * from p.filterable;
-$$ language sql stable;
+      create function p.protecteds_by_other_id (other_id int) returns setof p.protected as $$
+      select *
+      from p.protected
+      where other_id = other_id;
+      $$ language sql stable;
 
-comment on function p.func_tagged_filterable_returns_setof_filterable() is E'@filterable';
-
-create function p.func_tagged_filterable_returns_table_multi_col() returns table (col1 int, col2 text) as $$
-  select 42 as col1, 'out'::text as col2
-  union
-  select 43 as col1, 'out2'::text as col2;
-$$ language sql stable;
-
-comment on function p.func_tagged_filterable_returns_table_multi_col() is E'@filterable';
-
-create table p.protected (
-  id int primary key,
-  other_id int,
-  name text
-);
-
-comment on table p.protected is E'@omit all';
-
-create function p.protecteds_by_other_id (other_id int) returns setof p.protected as $$
-  select * from p.protected where other_id = other_id;
-$$ language sql stable;
-
-create table p.filterable_closure (
-  id serial primary key,
-  ancestor_id integer not null references p.filterable (id),
-  descendant_id integer not null references p.filterable (id),
-  depth integer not null
-);
-comment on table p.filterable_closure is E'@omit all';
+      create table p.filterable_closure
+      (
+        id serial primary key,
+        ancestor_id integer not null references p.filterable (id),
+        descendant_id integer not null references p.filterable (id),
+        depth integer not null
+      );
+      comment on table p.filterable_closure is E'@omit all';

--- a/__tests__/p-schema.sql
+++ b/__tests__/p-schema.sql
@@ -25,7 +25,7 @@ create table p.unique_taggs
   "content" text
 );
 
-comment on column p.unique_taggs.taggable_type is E'@isPolymorphic\n@polymorphicTo Parent\n@polymorphicTo Forward';
+comment on column p.unique_taggs.unique_taggable_type is E'@isPolymorphic\n@polymorphicTo Parent\n@polymorphicTo Forward';
 alter table p.unique_taggs add constraint unique_tag_type_is_unique UNIQUE (taggable_id,taggable_type);
 
 create table p.parent

--- a/__tests__/p-schema.sql
+++ b/__tests__/p-schema.sql
@@ -26,7 +26,7 @@ create table p.unique_taggs
 );
 
 comment on column p.unique_taggs.unique_taggable_type is E'@isPolymorphic\n@polymorphicTo Parent\n@polymorphicTo Forward';
-alter table p.unique_taggs add constraint unique_tag_type_is_unique UNIQUE (taggable_id,taggable_type);
+alter table p.unique_taggs add constraint unique_tag_type_is_unique UNIQUE (unique_taggable_id,unique_taggable_type);
 
 create table p.parent
 (

--- a/src/pgConnectionArgFilterBackwardPolyRelationPlugin.ts
+++ b/src/pgConnectionArgFilterBackwardPolyRelationPlugin.ts
@@ -148,7 +148,7 @@ export const addBackwardPolyRelationFilter = (builder: SchemaBuilder, option: Op
           return true;
         });
         const fieldName = inflection.backwardRelationByPolymorphic(
-          foreignTable, currentPoly.name, isForeignKeyUnique
+          foreignTable, currentPoly.name, isForeignKeyUnique,
         );
         // const fieldName = isForeignKeyUnique ? inflection.camelCase(
         //   inflection.singularize(foreignTable.name))

--- a/src/pgConnectionArgFilterBackwardPolyRelationPlugin.ts
+++ b/src/pgConnectionArgFilterBackwardPolyRelationPlugin.ts
@@ -70,8 +70,8 @@ export const addBackwardPolyRelationFilter = (builder: SchemaBuilder, option: Op
       return `${this.filterManyType(table, foreignTable)}Poly`;
     },
     backwardRelationByPolymorphic(table, polymorphicName: string, isUnique: boolean) {
-      // const fieldName = isUnique ? this.singularize(table.name) : table.name;
-      return this.camelCase(`${isUnique ? this.singularize(polymorphicName) : polymorphicName}`);
+      const fieldName = isUnique ? this.singularize(table.name) : table.name;
+      return this.camelCase(`${fieldName}-as-${polymorphicName}`);
     },
   }));
   const { pgSimpleCollections } = option;

--- a/src/pgConnectionArgFilterBackwardPolyRelationPlugin.ts
+++ b/src/pgConnectionArgFilterBackwardPolyRelationPlugin.ts
@@ -69,6 +69,10 @@ export const addBackwardPolyRelationFilter = (builder: SchemaBuilder, option: Op
     filterManyPolyType(table, foreignTable) {
       return `${this.filterManyType(table, foreignTable)}Poly`;
     },
+    backwardRelationByPolymorphic(table, polymorphicName: string, isUnique: boolean) {
+      // const fieldName = isUnique ? this.singularize(table.name) : table.name;
+      return this.camelCase(`${isUnique ? this.singularize(polymorphicName) : polymorphicName}`);
+    },
   }));
   const { pgSimpleCollections } = option;
   const hasConnections = pgSimpleCollections !== 'only';
@@ -143,9 +147,12 @@ export const addBackwardPolyRelationFilter = (builder: SchemaBuilder, option: Op
           // the two attributes must be xx_type, xx_id
           return true;
         });
-        const fieldName = isForeignKeyUnique ? inflection.camelCase(
-          inflection.singularize(foreignTable.name))
-          : inflection.camelCase(inflection.pluralize(foreignTable.name));
+        const fieldName = inflection.backwardRelationByPolymorphic(
+          foreignTable, currentPoly.name, isForeignKeyUnique
+        );
+        // const fieldName = isForeignKeyUnique ? inflection.camelCase(
+        //   inflection.singularize(foreignTable.name))
+        //   : inflection.camelCase(inflection.pluralize(foreignTable.name));
 
         memo.push({
           table,

--- a/src/pgConnectionArgFilterBackwardPolyRelationPlugin.ts
+++ b/src/pgConnectionArgFilterBackwardPolyRelationPlugin.ts
@@ -70,8 +70,9 @@ export const addBackwardPolyRelationFilter = (builder: SchemaBuilder, option: Op
       return `${this.filterManyType(table, foreignTable)}Poly`;
     },
     backwardRelationByPolymorphic(table, polymorphicName: string, isUnique: boolean) {
-      const fieldName = isUnique ? this.singularize(table.name) : table.name;
-      return this.camelCase(`${fieldName}-as-${polymorphicName}`);
+      // const fieldName = isUnique ? this.singularize(table.name) : table.name;
+      // return this.camelCase(`${fieldName}-as-${polymorphicName}`);
+      return this.camelCase(`${isUnique ? this.singularize(polymorphicName) : polymorphicName}`);
     },
   }));
   const { pgSimpleCollections } = option;


### PR DESCRIPTION
The backward association create a filter with the table name. 
example:
a `notes` table polymorphic to `posts` will yield a `notes` field in `PostFilter` object in the filter.  But this will have a problem if the same table is polymorphic associate to a table with different keys, For example, 
```
Post{
  special_taggable_id/type
  regular_taggable_id/type
}
```
This will resolve in conflict field name. Therefore, the name, instead of `tag` is changed to `taggable`. 