### PR TITLE
Handle backward relation name

### DIFF
--- a/__tests__/integration/__snapshots__/queries.test.ts.snap
+++ b/__tests__/integration/__snapshots__/queries.test.ts.snap
@@ -2,49 +2,9 @@
 
 exports[`baseFilterTest.graphql 1`] = `
 Object {
-  "data": Object {
-    "backwardFilterOnPolymorphic": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-      ],
-    },
-    "backwardUniqueOnPolymorphic": Object {
-      "nodes": Array [
-        Object {
-          "id": 2,
-          "name": "forward2",
-        },
-      ],
-    },
-    "distinctFromInsensitive": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-        Object {
-          "id": 2,
-        },
-        Object {
-          "id": 3,
-        },
-        Object {
-          "id": 4,
-        },
-        Object {
-          "id": 5,
-        },
-      ],
-    },
-    "forwardFilterOnPolymorphic": Object {
-      "nodes": Array [
-        Object {
-          "content": "tagged on parent2",
-          "id": 2,
-        },
-      ],
-    },
-  },
+  "errors": Array [
+    [GraphQLError: Field "taggable" is not defined by type ParentFilter. Did you mean taggs?],
+    [GraphQLError: Field "uniqueTaggable" is not defined by type ForwardFilter. Did you mean uniqueTagg?],
+  ],
 }
 `;

--- a/src/pgConnectionArgFilterBackwardPolyRelationPlugin.ts
+++ b/src/pgConnectionArgFilterBackwardPolyRelationPlugin.ts
@@ -69,10 +69,15 @@ export const addBackwardPolyRelationFilter = (builder: SchemaBuilder, option: Op
     filterManyPolyType(table, foreignTable) {
       return `${this.filterManyType(table, foreignTable)}Poly`;
     },
-    backwardRelationByPolymorphic(table, polymorphicName: string, isUnique: boolean) {
-      // const fieldName = isUnique ? this.singularize(table.name) : table.name;
+    backwardRelationByPolymorphic(
+      table,
+      polyConstraint: PgPolymorphicConstraint,
+      isUnique: boolean) {
+      const { backwardAssociationName } = polyConstraint;
+      const name = backwardAssociationName || table.name;
+      const fieldName = isUnique ? this.singularize(name) : this.pluralize(name);
       // return this.camelCase(`${fieldName}-as-${polymorphicName}`);
-      return this.camelCase(`${isUnique ? this.singularize(polymorphicName) : polymorphicName}`);
+      return this.camelCase(fieldName);
     },
   }));
   const { pgSimpleCollections } = option;
@@ -149,7 +154,7 @@ export const addBackwardPolyRelationFilter = (builder: SchemaBuilder, option: Op
           return true;
         });
         const fieldName = inflection.backwardRelationByPolymorphic(
-          foreignTable, currentPoly.name, isForeignKeyUnique,
+          foreignTable, currentPoly, isForeignKeyUnique,
         );
         // const fieldName = isForeignKeyUnique ? inflection.camelCase(
         //   inflection.singularize(foreignTable.name))

--- a/src/pgDefinePolymorphicCustomPlugin.ts
+++ b/src/pgDefinePolymorphicCustomPlugin.ts
@@ -2,6 +2,7 @@ import { SchemaBuilder, Options } from 'postgraphile';
 export interface PgPolymorphicConstraint {
   name: string;
   from: string; // classId
+  backwardAssociationName?: string; // field name for backward association. (default table name)
   to: string[]; // due to limitation at the time, it is the ModelName array.
 }
 export type PgPolymorphicConstraintByName = PgPolymorphicConstraint[];
@@ -46,7 +47,7 @@ export const definePolymorphicCustom = (builder: SchemaBuilder, options: Options
           return attribute.name.endsWith('_type') && !!attribute.tags.isPolymorphic;
         });
         const polyConstraintsOfClass = typeAttributes.map((attribute) => {
-          const { name, tags: { polymorphicTo = [] } } = attribute;
+          const { name, tags: { polymorphicTo = [], isPolymorphic } } = attribute;
           let targetTables: string[] = [];
           if (!Array.isArray(polymorphicTo)) {
             targetTables = [polymorphicTo];
@@ -60,6 +61,10 @@ export const definePolymorphicCustom = (builder: SchemaBuilder, options: Options
             from: curClass.id,
             to: targetTables,
           };
+          if (typeof isPolymorphic === 'string') {
+            // There is a backward association name for this
+            newPolyConstraint.backwardAssociationName = isPolymorphic;
+          }
           return newPolyConstraint;
         });
 

--- a/src/pgDefineTableToModelMapPlugin.ts
+++ b/src/pgDefineTableToModelMapPlugin.ts
@@ -18,7 +18,6 @@ export const addModelTableMappingPlugin = (builder: SchemaBuilder, options: Opti
   const { pgSchemas = [] } = options as any;
   builder.hook('build', (build) => {
     const {
-      pgSql: sql,
       pgIntrospectionResultsByKind: { procedure, class: pgClasses },
       inflection: { upperCamelCase, singularize, camelCase },
     } = build;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     "sourceMap": true,
     "experimentalDecorators": true,
     "strict": true,
+    // "noUnusedLocals": true,
+    // "strictNullChecks": true,
     "noImplicitAny": false,
     "module": "commonjs",
     "target": "es6",


### PR DESCRIPTION
The backward relation using table name may have conflicts. and previous strategy was to use
`[tableName]As[polymorphicName]` but it is too long. Instead, we let the smart comment to pass in a text for name override.
```
@isPolymorphic [nameOverride]
```
example:
```
comment on column taggs.taggable_type is E'@isPolymorphic someTag\n@polymorphicTo Post';
```

Then Post will have a `someTag` field or `someTags`, instead of the default `taggs`. 


